### PR TITLE
Fix race condition in result append

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func doMain() error {
 		}
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			sema <- 1 // acquire token
 			defer func() {
 				<-sema // release token
@@ -226,13 +227,6 @@ func doMain() error {
 				fset:  fset,
 				query: query,
 			}
-			defer func() {
-				mutex.Lock()
-				syms = append(syms, v.syms...)
-				mutex.Unlock()
-			}()
-
-			defer wg.Done()
 
 			if haveSrcDir {
 				path = filepath.Join(dir, "src", path)
@@ -249,6 +243,9 @@ func doMain() error {
 					ast.Inspect(f, v.Visit)
 				}
 			}
+			mutex.Lock()
+			syms = append(syms, v.syms...)
+			mutex.Unlock()
 		}()
 	})
 	wg.Wait()


### PR DESCRIPTION
Previously the waitgroup `Done()` call was deferred *after* the deferred result append -- meaning it was run *before* it, since defers are run LIFO, and the program that was blocked on the waitgroup `Wait()` call could continue before the full results were actually appended.

As there are no early returns, the append can simply be moved after the loop, making it more obvious when it runs, and the Done call can be deferred at the very top of the func handed to the group, so it is assured to be called when the function is _completely_ done (including after anything it defers further into the body).